### PR TITLE
Deploy to home infra: infra/ Terraform, CI workflows, Dockerfile fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,86 @@
+name: Build on Push
+run-name: Build Docker Image on Push
+
+on:
+  push:
+    branches:
+      - main
+    # App-code changes only. Infra, CI config and docs don't rebuild the image
+    # (and this keeps the auto image-bump PR from re-triggering a build).
+    paths-ignore:
+      - "infra/**"
+      - ".github/**"
+      - "docs/**"
+      - "*.md"
+  # Allow seeding the first image (or a manual rebuild) without an app change.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image ref
+        id: img
+        run: |
+          # GHCR repository names must be lowercase.
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "image=${REGISTRY}/${OWNER}/teamificator-web" >> "$GITHUB_OUTPUT"
+          echo "tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.img.outputs.image }}:${{ steps.img.outputs.tag }}
+            ${{ steps.img.outputs.image }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Update image-versions.yaml
+        run: |
+          yq -i ".image = \"${{ steps.img.outputs.image }}:${{ steps.img.outputs.tag }}\"" infra/image-versions.yaml
+
+      # Opens a PR bumping the pinned image so the terraform-plan / -apply
+      # workflows take over the actual deploy.
+      #
+      # NOTE: this uses the default GITHUB_TOKEN. PRs opened by GITHUB_TOKEN do
+      # NOT trigger other workflows, so terraform-plan will not run on this PR
+      # automatically. To get the plan to run on the bump PR, pass a PAT (or a
+      # GitHub App token) with `token: ${{ secrets.DEPLOY_PAT }}` below. Merging
+      # the PR still triggers terraform-apply either way (the merge is a normal
+      # push to main).
+      - name: Create PR with updated image tag
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update image to ${{ steps.img.outputs.tag }}"
+          branch: deploy/image-${{ steps.img.outputs.tag }}
+          title: "Deploy: update image to ${{ steps.img.outputs.tag }}"
+          body: |
+            Automated PR bumping the deployed image to
+            `${{ steps.img.outputs.image }}:${{ steps.img.outputs.tag }}`
+            after a successful build of ${{ github.sha }}.
+
+            Merging this runs `terraform apply` on the teamificator-web runner.

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,45 @@
+# Runs on the in-cluster teamificator-web-runner (ci-deploy ServiceAccount).
+# Terraform runs directly in the runner container, so the kubernetes provider +
+# backend authenticate via in-cluster config -- no credentials or kubeconfig
+# needed.
+
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    # Scoped to things that change the deployment. The image build in
+    # deploy.yml pushes :latest separately; bump image-versions.yaml to roll a
+    # new version through here.
+    paths:
+      - "infra/**"
+      - ".github/workflows/terraform-apply.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-teamificator-web-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on: teamificator-web-runner
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        run: terraform apply -input=false -auto-approve

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,115 @@
+# Runs on the in-cluster teamificator-web-runner (a pod running as the ci-deploy
+# ServiceAccount). Terraform runs directly in the runner container, so the
+# kubernetes provider + backend use in-cluster config -- no credentials needed.
+# The plan is posted as a PR comment; the previous plan comment is minimized
+# (hidden) first so a stale plan can't be mistaken for the current one.
+
+name: Terraform Plan
+
+on:
+  pull_request:
+    paths:
+      - "infra/**"
+      - ".github/workflows/terraform-plan.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: terraform-teamificator-web-plan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    runs-on: teamificator-web-runner
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        run: terraform init -input=false
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          set +e
+          terraform plan -input=false -no-color -out=tfplan 2>&1 | tee plan.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment plan on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- terraform-plan:teamificator-web -->';
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const sha = context.payload.pull_request.head.sha;
+            const ok = '${{ steps.plan.outputs.exitcode }}' === '0';
+
+            let plan = '';
+            try { plan = fs.readFileSync('infra/plan.txt', 'utf8'); }
+            catch (e) { plan = `Could not read plan output: ${e}`; }
+
+            // Keep under GitHub's ~65k comment limit; the tail holds the summary.
+            const MAX = 60000;
+            let truncated = false;
+            if (plan.length > MAX) { plan = plan.slice(-MAX); truncated = true; }
+
+            // Fence longer than any backtick run in the plan, so plan content
+            // can't prematurely close the code block.
+            const longestTicks = (plan.match(/`+/g) || []).reduce((m, s) => Math.max(m, s.length), 0);
+            const fence = '`'.repeat(Math.max(3, longestTicks + 1));
+
+            // Build with a template literal: the blank lines after </summary> and
+            // around the fence are REQUIRED for GitHub to render a code block
+            // inside <details> (do not strip them).
+            const truncNote = truncated
+              ? `> ⚠️ Output truncated to the last ${MAX} chars — full log in the [workflow run](${runUrl}).\n\n`
+              : '';
+            const body =
+              `${marker}\n\n` +
+              `### Terraform Plan — \`infra\` ${ok ? '✅' : '❌ failed'}\n\n` +
+              truncNote +
+              `<details><summary>Show plan</summary>\n\n` +
+              `${fence}terraform\n` +
+              `${plan}\n` +
+              `${fence}\n\n` +
+              `</details>\n\n` +
+              `_Commit \`${sha}\` · [workflow run](${runUrl})_`;
+
+            // 1) Hide previous plan comments (mark OUTDATED) before posting the new one.
+            const q = `query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner, name:$repo){
+                pullRequest(number:$pr){
+                  comments(first:100){ nodes { id body isMinimized } }
+                }
+              }
+            }`;
+            const res = await github.graphql(q, { owner, repo, pr: prNumber });
+            for (const c of res.repository.pullRequest.comments.nodes) {
+              if (c.body.includes(marker) && !c.isMinimized) {
+                await github.graphql(
+                  `mutation($id:ID!){ minimizeComment(input:{subjectId:$id, classifier:OUTDATED}){ minimizedComment{ isMinimized } } }`,
+                  { id: c.id }
+                );
+              }
+            }
+
+            // 2) Post the fresh plan.
+            await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+
+      - name: Fail if plan errored
+        if: steps.plan.outputs.exitcode != '0'
+        run: exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG NODE_VERSION=21.1.0
 
 ################################################################################
 # Use node image for base image for all stages.
-FROM node:${NODE_VERSION}-alpine as base
+FROM node:${NODE_VERSION}-alpine AS base
 
 # Set working directory for all build stages.
 WORKDIR /usr/src/app
@@ -18,7 +18,7 @@ WORKDIR /usr/src/app
 
 ################################################################################
 # Create a stage for installing production dependecies.
-FROM base as deps
+FROM base AS deps
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.npm to speed up subsequent builds.
@@ -31,7 +31,7 @@ RUN --mount=type=bind,source=package.json,target=package.json \
 
 ################################################################################
 # Create a stage for building the application.
-FROM deps as build
+FROM deps AS build
 
 # Download additional development dependencies before building, as some projects require
 # "devDependencies" to be installed to build. If you don't need this, remove this step.
@@ -48,10 +48,10 @@ RUN npm run build
 ################################################################################
 # Create a new stage to run the application with minimal runtime dependencies
 # where the necessary files are copied from the build stage.
-FROM base as final
+FROM base AS final
 
 # Use production node environment by default.
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 # Run the application as a non-root user.
 USER node
@@ -63,10 +63,12 @@ COPY package.json .
 # the built application from the build stage into the image.
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/.next ./.next
+COPY --from=build /usr/src/app/public ./public
+COPY --from=build /usr/src/app/next.config.ts ./next.config.ts
 
 
 # Expose the port that the application listens on.
 EXPOSE 3000
 
 # Run the application.
-CMD npm start
+CMD ["npm", "start"]

--- a/infra/image-versions.yaml
+++ b/infra/image-versions.yaml
@@ -1,0 +1,7 @@
+# Container image to deploy. The build workflow (.github/workflows/deploy.yml)
+# pushes this on every merge to main. Pin a specific tag or @sha256 digest here
+# for reproducible, roll-forward-only deploys instead of the mutable :latest.
+#
+# Seeded with :latest for the first deploy; after the first build the deploy
+# workflow opens a PR bumping this to the immutable sha-<commit> tag.
+image: ghcr.io/aimbotparce/teamificator-web:latest

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,146 @@
+###############################################################################
+# teamificator.parcerisa.dev -- Teamificator web app
+#
+# Stateless Next.js app (listens on :3000). No PVC: nothing to persist. Served
+# publicly through HomeInfra's Traefik "public" ingress, which terminates TLS
+# with a Let's Encrypt certificate for each host in var.public_hosts.
+#
+# The namespace, GHCR pull secret (on the default ServiceAccount) and the
+# ci-deploy RBAC used to apply this are provisioned by HomeInfra.
+###############################################################################
+
+locals {
+  image  = yamldecode(file("${path.module}/${var.image_versions_file}")).image
+  labels = { "app.kubernetes.io/name" = "teamificator-web" }
+}
+
+resource "kubernetes_deployment_v1" "web" {
+  metadata {
+    name      = "teamificator-web"
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = local.labels
+    }
+
+    template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        container {
+          name  = "web"
+          image = local.image
+          # :latest is mutable, so always re-pull on (re)start. Pin a digest or
+          # version tag in image-versions.yaml for reproducible rollouts.
+          image_pull_policy = "Always"
+
+          port {
+            name           = "http"
+            container_port = 3000
+          }
+
+          env {
+            name  = "NODE_ENV"
+            value = "production"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 3000
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 3000
+            }
+            initial_delay_seconds = 15
+            period_seconds        = 20
+          }
+
+          resources {
+            requests = {
+              cpu    = "50m"
+              memory = "128Mi"
+            }
+            limits = {
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "web" {
+  metadata {
+    name      = "teamificator-web"
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    selector = local.labels
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 3000
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "web" {
+  metadata {
+    name      = "teamificator-web"
+    namespace = var.namespace
+  }
+
+  spec {
+    ingress_class_name = "public"
+
+    dynamic "rule" {
+      for_each = toset(var.public_hosts)
+
+      content {
+        host = rule.value
+
+        http {
+          path {
+            path      = "/"
+            path_type = "Prefix"
+
+            backend {
+              service {
+                name = kubernetes_service_v1.web.metadata[0].name
+                port {
+                  number = 80
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # Names the hosts for TLS so the websecure entrypoint's Let's Encrypt
+    # resolver issues certificates. No secret_name: the certs are managed by
+    # Traefik's ACME resolver.
+    tls {
+      hosts = var.public_hosts
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,32 @@
+variable "kubeconfig_path" {
+  description = "Path to a kubeconfig for out-of-cluster runs. Leave null in CI to use the runner pod's in-cluster config."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "namespace" {
+  description = "Namespace provisioned for this app by HomeInfra (apps.tf key)."
+  type        = string
+  default     = "teamificator-web"
+}
+
+variable "image_versions_file" {
+  description = "YAML file pinning the container image to deploy."
+  type        = string
+  default     = "image-versions.yaml"
+}
+
+variable "public_hosts" {
+  description = "Public hostnames Traefik should route to this app (TLS via Let's Encrypt)."
+  type        = list(string)
+  default = [
+    "teamificator.parcerisa.dev",
+  ]
+}
+
+variable "replicas" {
+  description = "Number of app replicas."
+  type        = number
+  default     = 2
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.5"
+
+  # State is a Secret (+ a Lease for locking) in this app's namespace, written
+  # by the runner's ci-deploy ServiceAccount. No cloud backend, no credentials.
+  backend "kubernetes" {
+    secret_suffix     = "state"
+    namespace         = "teamificator-web"
+    in_cluster_config = true
+  }
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+}
+
+# null kubeconfig_path -> in-cluster config (the runner pod's ci-deploy token).
+# Set it only for out-of-cluster (laptop) runs.
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}


### PR DESCRIPTION
## Summary

Sets up TeamificatorWebPage to deploy onto the home k3s cluster, following the HomeInfra `docs/deploying-k8s-app` model and mirroring PersonalWebPage. The app is a stateless Next.js app on `:3000` (no DB/PVC), exposed **publicly** at `teamificator.parcerisa.dev` via Traefik's `public` ingress with Let's Encrypt TLS.

## Changes

- **`infra/versions.tf`** — Terraform `kubernetes` backend; state stored as a Secret (+ Lease) in the `teamificator-web` namespace via in-cluster config. No cloud credentials.
- **`infra/variables.tf`** — knobs incl. `public_hosts = ["teamificator.parcerisa.dev"]`, `replicas = 2`.
- **`infra/main.tf`** — Deployment + Service + `public` Ingress. Hostname is listed under `tls.hosts` so Traefik's ACME resolver issues a Let's Encrypt cert.
- **`infra/image-versions.yaml`** — pins the deployed image (seeded at `ghcr.io/aimbotparce/teamificator-web:latest`; bumped to `sha-<commit>` by the build workflow).
- **`.github/workflows/deploy.yml`** — builds & pushes the image to GHCR on merge to `main`, then opens an image-bump PR.
- **`.github/workflows/terraform-plan.yml`** — `terraform plan` on PRs touching `infra/`, posted as a PR comment. Runs on `teamificator-web-runner`.
- **`.github/workflows/terraform-apply.yml`** — `terraform apply -auto-approve` on merge to `main`. Runs on `teamificator-web-runner`.
- **`Dockerfile`** — copy `public/` and `next.config.ts` into the final image and use exec-form `CMD` so static assets and config are served at runtime (the previous Dockerfile omitted them).

## Prerequisites / order

1. Merge the companion HomeInfra PR and `terraform apply` the `k8s` env from home — this creates the `teamificator-web` namespace and registers the `teamificator-web-runner`.
2. Run **Build on Push** (workflow_dispatch) to seed the first image in GHCR.
3. Merge this PR (and the auto image-bump PR) → `terraform-apply` deploys on the runner.
4. Point DNS for `teamificator.parcerisa.dev` at the public ingress.

App comes up at `https://teamificator.parcerisa.dev` (first load lags while ACME issues the cert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188wPZL775MAjqyqoV3HEBc

---
_Generated by [Claude Code](https://claude.ai/code/session_0188wPZL775MAjqyqoV3HEBc)_