### PR TITLE
Fix crash-loop: convert next.config.ts to .mjs (no runtime TypeScript)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY package.json .
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/.next ./.next
 COPY --from=build /usr/src/app/public ./public
-COPY --from=build /usr/src/app/next.config.ts ./next.config.ts
+COPY --from=build /usr/src/app/next.config.mjs ./next.config.mjs
 
 
 # Expose the port that the application listens on.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary

Fixes the container crash-loop that left the `terraform apply` stuck on `kubernetes_deployment_v1.web: Still modifying…` (the provider waits for the rollout, and the new pods never became Ready).

## Root cause

From the pod logs:

```
⚠ Installing TypeScript as it was not found while loading "next.config.ts".
...
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

`next start` loads the Next config at runtime. Because the config is `next.config.**ts**`, Next needs the `typescript` package to parse it — but the runtime image only carries production deps (`npm ci --omit=dev`), so `typescript` isn't present. Next then tried to install it on the fly (`yarn add typescript`) inside the container; with no lockfile it resolved the whole dependency tree, exceeded the pod's memory limit, and OOM-crashed → CrashLoopBackOff → rollout stuck.

## Fix

- Convert the (empty) `next.config.ts` → **`next.config.mjs`** (plain ESM). No TypeScript needed at runtime.
- Update the Dockerfile to copy `next.config.mjs` into the final image.

Verified the config loads under Node and no references to the old `.ts` remain.

## Rollout

Requires a **rebuilt image** to take effect (the fix ships in the image). Merging this triggers **Build on Push**; once the image-bump PR lands, `terraform apply` should roll out cleanly and the pods will reach Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188wPZL775MAjqyqoV3HEBc

---
_Generated by [Claude Code](https://claude.ai/code/session_0188wPZL775MAjqyqoV3HEBc)_